### PR TITLE
Zns#resolution(domain: string)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build
 lib
 node_modules
 tmp
+docs
+docs/index.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Make Zns#getContractField #getContractMapValue and #getResolverRecordsStructure private methods
+* Added Zns#resolution method which returns everything what is stored on zilliqa for specific domain
 
 ## 0.2.39 - 0.2.40
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "namicorn",
-	"version": "0.2.39",
+	"version": "0.2.40",
 	"description": "Crypto currency wallet domain name resolution library by Unstoppable Domains Inc.",
 	"main": "./lib/namicorn.js",
 	"types": "./lib/namicorn.d.ts",

--- a/src/Ens.ts
+++ b/src/Ens.ts
@@ -145,10 +145,6 @@ export default class Ens extends NamingService {
     return address;
   }
 
-  async resolution(domain:string) : Promise<any | null> {
-   return Promise.resolve(null);
-  }
-
   /*===========================*/
 
   protected normalizeSource(

--- a/src/Ens.ts
+++ b/src/Ens.ts
@@ -144,6 +144,11 @@ export default class Ens extends NamingService {
     const address = await resolverContract.methods.addr(nodeHash).call();
     return address;
   }
+
+  async resolution(domain:string) : Promise<any | null> {
+   return Promise.resolve(null);
+  }
+
   /*===========================*/
 
   protected normalizeSource(

--- a/src/Namicorn.test.ts
+++ b/src/Namicorn.test.ts
@@ -228,15 +228,27 @@ describe('ENS', () => {
   });
 
   it('resolves .eth name using blockchain', async () => {
-    const testName = 'resolves .eth name using blockchain';
-    mockAPICalls('ENS', testName, MainnetUrl);
-
     const namicorn = new Namicorn({
       blockchain: { ens: true },
     });
     expect(namicorn.ens.url).toBe('https://mainnet.infura.io');
     expect(namicorn.ens.network).toEqual('mainnet');
+
+    const eye = jest
+      .spyOn(namicorn.ens, '_getResolutionInfo')
+      .mockImplementation(() => Promise.resolve([
+        '0x714ef33943d925731FBB89C99aF5780D888bD106',
+        '0',
+        '0x5FfC014343cd971B7eb70732021E26C35B744cc4'
+      ]));
+
+      const secondEye = jest
+        .spyOn(namicorn.ens, '_fetchAddress')
+        .mockImplementation(() => Promise.resolve('0x714ef33943d925731FBB89C99aF5780D888bD106'));
+
     var result = await namicorn.address('matthewgould.eth', 'ETH');
+    expect(eye).toHaveBeenCalled();
+    expect(secondEye).toHaveBeenCalled();
     expect(result).toEqual('0x714ef33943d925731FBB89C99aF5780D888bD106');
   });
 

--- a/src/Namicorn.test.ts
+++ b/src/Namicorn.test.ts
@@ -216,14 +216,14 @@ describe('ZNS', () => {
     const namicorn = new Namicorn();
 
     const eye = jest
-      .spyOn(namicorn.zns, 'getRecordsAddresses')
+      .spyOn(namicorn.zns, '_getRecordsAddresses')
       .mockResolvedValue([
         'zil194qcjskuuxh6qtg8xw3qqrr3kdc6dtq8ct6j9s',
         '0xdac22230adfe4601f00631eae92df6d77f054891',
       ]);
 
     const secondEye = jest
-      .spyOn(namicorn.zns, 'getResolverRecordsStructure')
+      .spyOn(namicorn.zns, '_getResolverRecordsStructure')
       .mockResolvedValue({
         crypto: {
           BCH: { address: 'qrq4sk49ayvepqz7j7ep8x4km2qp8lauvcnzhveyu6' },
@@ -260,14 +260,14 @@ describe('ZNS', () => {
   it('should resolve with resolution key setuped SECOND', async () => {
     const namicorn = new Namicorn();
     const eye = jest
-      .spyOn(namicorn.zns, 'getRecordsAddresses')
+      .spyOn(namicorn.zns, '_getRecordsAddresses')
       .mockResolvedValue([
         'zil1f6vyj5hgvll3xtx5kuxd8ucn66x9zxmkp34agy',
         '0xa9b1d3647e4deb9ce4e601c2c9e0a2fdf2d7415a',
       ]);
 
     const secondEye = jest
-      .spyOn(namicorn.zns, 'getResolverRecordsStructure')
+      .spyOn(namicorn.zns, '_getResolverRecordsStructure')
       .mockResolvedValue({
         ipfs: {
           html: {

--- a/src/Namicorn.test.ts
+++ b/src/Namicorn.test.ts
@@ -213,6 +213,105 @@ describe('ZNS', () => {
       'zil1408llufrzkrrfqv5lj4malcjxyjqyd8urd7xz6',
     );
   });
+
+  it('should resolve with resolution key setuped', async () => {
+    const namicorn = new Namicorn();
+
+    const eye = jest
+      .spyOn(namicorn.zns, 'getRecordsAddresses')
+      .mockResolvedValue([ 'zil194qcjskuuxh6qtg8xw3qqrr3kdc6dtq8ct6j9s',
+      '0xdac22230adfe4601f00631eae92df6d77f054891' ]);
+
+    const secondEye = jest
+      .spyOn(namicorn.zns, 'getResolverRecordsStructure')
+      .mockResolvedValue({ crypto:
+        { BCH: { address: 'qrq4sk49ayvepqz7j7ep8x4km2qp8lauvcnzhveyu6' },
+          BTC: { address: '1EVt92qQnaLDcmVFtHivRJaunG2mf2C3mB' },
+          ETH: { address: '0x45b31e01AA6f42F0549aD482BE81635ED3149abb' },
+          LTC: { address: 'LetmswTW3b7dgJ46mXuiXMUY17XbK29UmL' },
+          ZIL: { address: 'zil1yu5u4hegy9v3xgluweg4en54zm8f8auwxu0xxj' } },
+       ipfs:
+        { html: { value: 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK' },
+          redirect_domain: { value: 'www.unstoppabledomains.com' } } });
+
+    const result = await namicorn.resolution('brad.zil');
+
+    expect(eye).toHaveBeenCalled();
+    expect(secondEye).toHaveBeenCalled();
+    expect(result).toEqual({
+      resolution: {
+        ipfs:
+        {
+          html: { value: 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK' },
+          redirect_domain: { value: 'www.unstoppabledomains.com' }
+        }
+      },
+      addresses:
+      {
+        BCH: 'qrq4sk49ayvepqz7j7ep8x4km2qp8lauvcnzhveyu6',
+        BTC: '1EVt92qQnaLDcmVFtHivRJaunG2mf2C3mB',
+        ETH: '0x45b31e01AA6f42F0549aD482BE81635ED3149abb',
+        LTC: 'LetmswTW3b7dgJ46mXuiXMUY17XbK29UmL',
+        ZIL: 'zil1yu5u4hegy9v3xgluweg4en54zm8f8auwxu0xxj'
+      },
+      meta:
+      {
+        owner: 'zil194qcjskuuxh6qtg8xw3qqrr3kdc6dtq8ct6j9s',
+        type: 'zns',
+        ttl: 0
+      }
+    })
+  });
+  
+  it('should resolve with resolution key setuped SECOND', async () => {
+    const namicorn = new Namicorn();
+    const eye = jest
+      .spyOn(namicorn.zns, 'getRecordsAddresses')
+      .mockResolvedValue( [ 'zil1f6vyj5hgvll3xtx5kuxd8ucn66x9zxmkp34agy',
+      '0xa9b1d3647e4deb9ce4e601c2c9e0a2fdf2d7415a' ]);
+
+    const secondEye = jest
+      .spyOn(namicorn.zns, 'getResolverRecordsStructure')
+      .mockResolvedValue({ ipfs:
+        { html:
+           { hash: 'QmefehFs5n8yQcGCVJnBMY3Hr6aMRHtsoniAhsM1KsHMSe',
+             value: 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK' },
+          redirect_domain: { value: 'www.unstoppabledomains.com' } },
+       whois:
+        { email: { value: 'matt+test@unstoppabledomains.com' },
+          for_sale: { value: 'true' } } });
+
+
+
+    const result = await namicorn.resolution('ergergergerg.zil');
+    expect(eye).toHaveBeenCalled();
+    expect(secondEye).toHaveBeenCalled();
+    expect(result).toEqual({
+      resolution: {
+        ipfs:
+        {
+          html:
+          {
+            hash: 'QmefehFs5n8yQcGCVJnBMY3Hr6aMRHtsoniAhsM1KsHMSe',
+            value: 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK'
+          },
+          redirect_domain: { value: 'www.unstoppabledomains.com' }
+        },
+        whois:
+        {
+          email: { value: 'matt+test@unstoppabledomains.com' },
+          for_sale: { value: 'true' }
+        }
+      },
+      addresses: {},
+      meta:
+      {
+        owner: 'zil1f6vyj5hgvll3xtx5kuxd8ucn66x9zxmkp34agy',
+        type: 'zns',
+        ttl: 0
+      }
+    });
+  })
 });
 
 describe('ENS', () => {
@@ -242,9 +341,9 @@ describe('ENS', () => {
         '0x5FfC014343cd971B7eb70732021E26C35B744cc4'
       ]));
 
-      const secondEye = jest
-        .spyOn(namicorn.ens, '_fetchAddress')
-        .mockImplementation(() => Promise.resolve('0x714ef33943d925731FBB89C99aF5780D888bD106'));
+    const secondEye = jest
+      .spyOn(namicorn.ens, '_fetchAddress')
+      .mockImplementation(() => Promise.resolve('0x714ef33943d925731FBB89C99aF5780D888bD106'));
 
     var result = await namicorn.address('matthewgould.eth', 'ETH');
     expect(eye).toHaveBeenCalled();
@@ -502,6 +601,13 @@ describe('ENS', () => {
     expect(namicorn.ens.url).toBe('https://custom.notinfura.io');
     expect(namicorn.ens.registryAddress).toBeUndefined();
   });
+
+  it('should return null since ens does not support full resolution', async () => {
+    const namicorn = new Namicorn();
+    const invalid = await namicorn.resolution('matthewgould.eth');
+    expect(invalid).toBe(null);
+  })
+
 });
 
 it('provides empty response constant', async () => {

--- a/src/Namicorn.test.ts
+++ b/src/Namicorn.test.ts
@@ -257,7 +257,7 @@ describe('ZNS', () => {
     });
   });
 
-  it('should resolve with resolution key setuped SECOND', async () => {
+  it('should resolve with resolution key setuped #2', async () => {
     const namicorn = new Namicorn();
     const eye = jest
       .spyOn(namicorn.zns, '_getRecordsAddresses')
@@ -299,6 +299,36 @@ describe('ZNS', () => {
       },
     });
   });
+
+  it('should resolve with resolution key setuped #3', async () => {
+    const namicorn = new Namicorn();
+    const zns = namicorn.zns;
+
+    expect(zns).toBeDefined();
+    const result = await zns.resolution('invalid.domain');
+    expect(result).toEqual({});
+  })
+
+  it('should resolve with resolution key setuped #4', async () => {
+    const namicorn = new Namicorn();
+    const zns = namicorn.zns;
+    expect(zns).toBeDefined();
+    const result = await zns.resolution('mcafee2020.zil');
+    expect(result).toEqual({
+      crypto:
+      {
+        BTC: { address: '17LV6fxL8b1pJomn5zoDR3ZCnbt88ehGBf' },
+        ETH: { address: '0x0ed6180ef7c638064b9b17ff53ba76ec7077dd95' },
+        LTC: { address: 'MTbeoMfWqEZaaZVG1yE1ENoxVGNmMAxoEj' }
+      },
+      whois:
+      {
+        email: { value: 'jordanb_970@hotmail.com' },
+        for_sale: { value: 'true' }
+      }
+    });
+  })
+
 });
 
 describe('ENS', () => {

--- a/src/Namicorn.test.ts
+++ b/src/Namicorn.test.ts
@@ -75,14 +75,12 @@ describe('ZNS', () => {
     const namicorn = new Namicorn({ blockchain: true });
     const result = await namicorn.resolve('test-manage-one.zil');
     expect(result.addresses).toEqual({ BURST: 'BURST-R7KK-SBSY-FENX-AWYMW' });
-    expect(result.meta).toEqual(
-      {
-        owner: 'zil1zzpjwyp2nu29pcv3sh04qxq9x5l45vke0hrwec',
-        type: 'zns',
-        ttl: 0
-      }
-    );
-  })
+    expect(result.meta).toEqual({
+      owner: 'zil1zzpjwyp2nu29pcv3sh04qxq9x5l45vke0hrwec',
+      type: 'zns',
+      ttl: 0,
+    });
+  });
 
   it("doesn't support zil domain when zns is disabled", () => {
     const namicorn = new Namicorn({ blockchain: { zns: false } });
@@ -219,99 +217,88 @@ describe('ZNS', () => {
 
     const eye = jest
       .spyOn(namicorn.zns, 'getRecordsAddresses')
-      .mockResolvedValue([ 'zil194qcjskuuxh6qtg8xw3qqrr3kdc6dtq8ct6j9s',
-      '0xdac22230adfe4601f00631eae92df6d77f054891' ]);
+      .mockResolvedValue([
+        'zil194qcjskuuxh6qtg8xw3qqrr3kdc6dtq8ct6j9s',
+        '0xdac22230adfe4601f00631eae92df6d77f054891',
+      ]);
 
     const secondEye = jest
       .spyOn(namicorn.zns, 'getResolverRecordsStructure')
-      .mockResolvedValue({ crypto:
-        { BCH: { address: 'qrq4sk49ayvepqz7j7ep8x4km2qp8lauvcnzhveyu6' },
+      .mockResolvedValue({
+        crypto: {
+          BCH: { address: 'qrq4sk49ayvepqz7j7ep8x4km2qp8lauvcnzhveyu6' },
           BTC: { address: '1EVt92qQnaLDcmVFtHivRJaunG2mf2C3mB' },
           ETH: { address: '0x45b31e01AA6f42F0549aD482BE81635ED3149abb' },
           LTC: { address: 'LetmswTW3b7dgJ46mXuiXMUY17XbK29UmL' },
-          ZIL: { address: 'zil1yu5u4hegy9v3xgluweg4en54zm8f8auwxu0xxj' } },
-       ipfs:
-        { html: { value: 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK' },
-          redirect_domain: { value: 'www.unstoppabledomains.com' } } });
+          ZIL: { address: 'zil1yu5u4hegy9v3xgluweg4en54zm8f8auwxu0xxj' },
+        },
+        ipfs: {
+          html: { value: 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK' },
+          redirect_domain: { value: 'www.unstoppabledomains.com' },
+        },
+      });
 
-    const result = await namicorn.resolution('brad.zil');
+    const result = await namicorn.zns.resolution('brad.zil');
 
     expect(eye).toHaveBeenCalled();
     expect(secondEye).toHaveBeenCalled();
     expect(result).toEqual({
-      resolution: {
-        ipfs:
-        {
-          html: { value: 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK' },
-          redirect_domain: { value: 'www.unstoppabledomains.com' }
-        }
+      crypto: {
+        BCH: { address: 'qrq4sk49ayvepqz7j7ep8x4km2qp8lauvcnzhveyu6' },
+        BTC: { address: '1EVt92qQnaLDcmVFtHivRJaunG2mf2C3mB' },
+        ETH: { address: '0x45b31e01AA6f42F0549aD482BE81635ED3149abb' },
+        LTC: { address: 'LetmswTW3b7dgJ46mXuiXMUY17XbK29UmL' },
+        ZIL: { address: 'zil1yu5u4hegy9v3xgluweg4en54zm8f8auwxu0xxj' },
       },
-      addresses:
-      {
-        BCH: 'qrq4sk49ayvepqz7j7ep8x4km2qp8lauvcnzhveyu6',
-        BTC: '1EVt92qQnaLDcmVFtHivRJaunG2mf2C3mB',
-        ETH: '0x45b31e01AA6f42F0549aD482BE81635ED3149abb',
-        LTC: 'LetmswTW3b7dgJ46mXuiXMUY17XbK29UmL',
-        ZIL: 'zil1yu5u4hegy9v3xgluweg4en54zm8f8auwxu0xxj'
+      ipfs: {
+        html: { value: 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK' },
+        redirect_domain: { value: 'www.unstoppabledomains.com' },
       },
-      meta:
-      {
-        owner: 'zil194qcjskuuxh6qtg8xw3qqrr3kdc6dtq8ct6j9s',
-        type: 'zns',
-        ttl: 0
-      }
-    })
+    });
   });
-  
+
   it('should resolve with resolution key setuped SECOND', async () => {
     const namicorn = new Namicorn();
     const eye = jest
       .spyOn(namicorn.zns, 'getRecordsAddresses')
-      .mockResolvedValue( [ 'zil1f6vyj5hgvll3xtx5kuxd8ucn66x9zxmkp34agy',
-      '0xa9b1d3647e4deb9ce4e601c2c9e0a2fdf2d7415a' ]);
+      .mockResolvedValue([
+        'zil1f6vyj5hgvll3xtx5kuxd8ucn66x9zxmkp34agy',
+        '0xa9b1d3647e4deb9ce4e601c2c9e0a2fdf2d7415a',
+      ]);
 
     const secondEye = jest
       .spyOn(namicorn.zns, 'getResolverRecordsStructure')
-      .mockResolvedValue({ ipfs:
-        { html:
-           { hash: 'QmefehFs5n8yQcGCVJnBMY3Hr6aMRHtsoniAhsM1KsHMSe',
-             value: 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK' },
-          redirect_domain: { value: 'www.unstoppabledomains.com' } },
-       whois:
-        { email: { value: 'matt+test@unstoppabledomains.com' },
-          for_sale: { value: 'true' } } });
+      .mockResolvedValue({
+        ipfs: {
+          html: {
+            hash: 'QmefehFs5n8yQcGCVJnBMY3Hr6aMRHtsoniAhsM1KsHMSe',
+            value: 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK',
+          },
+          redirect_domain: { value: 'www.unstoppabledomains.com' },
+        },
+        whois: {
+          email: { value: 'matt+test@unstoppabledomains.com' },
+          for_sale: { value: 'true' },
+        },
+      });
 
-
-
-    const result = await namicorn.resolution('ergergergerg.zil');
+    const result = await namicorn.zns.resolution('ergergergerg.zil');
     expect(eye).toHaveBeenCalled();
     expect(secondEye).toHaveBeenCalled();
     expect(result).toEqual({
-      resolution: {
-        ipfs:
-        {
-          html:
-          {
-            hash: 'QmefehFs5n8yQcGCVJnBMY3Hr6aMRHtsoniAhsM1KsHMSe',
-            value: 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK'
-          },
-          redirect_domain: { value: 'www.unstoppabledomains.com' }
+      ipfs: {
+        html: {
+          hash: 'QmefehFs5n8yQcGCVJnBMY3Hr6aMRHtsoniAhsM1KsHMSe',
+          value: 'QmVaAtQbi3EtsfpKoLzALm6vXphdi2KjMgxEDKeGg6wHuK',
         },
-        whois:
-        {
-          email: { value: 'matt+test@unstoppabledomains.com' },
-          for_sale: { value: 'true' }
-        }
+        redirect_domain: { value: 'www.unstoppabledomains.com' },
       },
-      addresses: {},
-      meta:
-      {
-        owner: 'zil1f6vyj5hgvll3xtx5kuxd8ucn66x9zxmkp34agy',
-        type: 'zns',
-        ttl: 0
-      }
+      whois: {
+        email: { value: 'matt+test@unstoppabledomains.com' },
+        for_sale: { value: 'true' },
+      },
     });
-  })
+  });
 });
 
 describe('ENS', () => {
@@ -335,15 +322,19 @@ describe('ENS', () => {
 
     const eye = jest
       .spyOn(namicorn.ens, '_getResolutionInfo')
-      .mockImplementation(() => Promise.resolve([
-        '0x714ef33943d925731FBB89C99aF5780D888bD106',
-        '0',
-        '0x5FfC014343cd971B7eb70732021E26C35B744cc4'
-      ]));
+      .mockImplementation(() =>
+        Promise.resolve([
+          '0x714ef33943d925731FBB89C99aF5780D888bD106',
+          '0',
+          '0x5FfC014343cd971B7eb70732021E26C35B744cc4',
+        ]),
+      );
 
     const secondEye = jest
       .spyOn(namicorn.ens, '_fetchAddress')
-      .mockImplementation(() => Promise.resolve('0x714ef33943d925731FBB89C99aF5780D888bD106'));
+      .mockImplementation(() =>
+        Promise.resolve('0x714ef33943d925731FBB89C99aF5780D888bD106'),
+      );
 
     var result = await namicorn.address('matthewgould.eth', 'ETH');
     expect(eye).toHaveBeenCalled();
@@ -601,13 +592,6 @@ describe('ENS', () => {
     expect(namicorn.ens.url).toBe('https://custom.notinfura.io');
     expect(namicorn.ens.registryAddress).toBeUndefined();
   });
-
-  it('should return null since ens does not support full resolution', async () => {
-    const namicorn = new Namicorn();
-    const invalid = await namicorn.resolution('matthewgould.eth');
-    expect(invalid).toBe(null);
-  })
-
 });
 
 it('provides empty response constant', async () => {

--- a/src/Namicorn.ts
+++ b/src/Namicorn.ts
@@ -92,11 +92,16 @@ class Namicorn {
     return method && method.isSupportedNetwork();
   }
 
-  private async resolveUsingBlockchain(domain: string) {
+  private getNamingMethod(domain: string) {
     const methods = [this.ens, this.zns];
     const method = methods.find(
       method => method && method.isSupportedDomain(domain),
     );
+    return method || null;
+  }
+
+  private async resolveUsingBlockchain(domain: string) {
+    const method = this.getNamingMethod(domain);
     if (!method) return null;
     var result = method && (await method.resolve(domain));
     return result || Namicorn.UNCLAIMED_DOMAIN_RESPONSE;

--- a/src/Namicorn.ts
+++ b/src/Namicorn.ts
@@ -77,13 +77,6 @@ class Namicorn {
     return await this.ens.reverse(address, currencyTicker);
   }
 
-  async resolution(domain: string): Promise<Object | null> {
-    const method = this.getNamingMethod(domain);
-    if (!method) return null;
-    const result = await method.resolution(domain); 
-    return result || null;
-  }
-
   isSupportedDomain(domain: string): boolean {
     return (
       (this.zns && this.zns.isSupportedDomain(domain)) ||

--- a/src/Namicorn.ts
+++ b/src/Namicorn.ts
@@ -77,6 +77,13 @@ class Namicorn {
     return await this.ens.reverse(address, currencyTicker);
   }
 
+  async resolution(domain: string): Promise<Object | null> {
+    const method = this.getNamingMethod(domain);
+    if (!method) return null;
+    const result = await method.resolution(domain); 
+    return result || null;
+  }
+
   isSupportedDomain(domain: string): boolean {
     return (
       (this.zns && this.zns.isSupportedDomain(domain)) ||
@@ -103,7 +110,7 @@ class Namicorn {
   private async resolveUsingBlockchain(domain: string) {
     const method = this.getNamingMethod(domain);
     if (!method) return null;
-    var result = method && (await method.resolve(domain));
+    const result = await method.resolve(domain);
     return result || Namicorn.UNCLAIMED_DOMAIN_RESPONSE;
   }
 }

--- a/src/NamingService.ts
+++ b/src/NamingService.ts
@@ -3,7 +3,6 @@ import { SourceDefinition } from './types';
 export default abstract class NamingService {
   abstract isSupportedDomain(domain: string): boolean;
   abstract isSupportedNetwork(): boolean;
-  abstract resolution(domain: string): Promise<Object | null>;
   protected abstract normalizeSource(
     source: boolean | string | SourceDefinition,
   );

--- a/src/NamingService.ts
+++ b/src/NamingService.ts
@@ -3,6 +3,7 @@ import { SourceDefinition } from './types';
 export default abstract class NamingService {
   abstract isSupportedDomain(domain: string): boolean;
   abstract isSupportedNetwork(): boolean;
+  abstract resolution(domain: string): Promise<Object | null>;
   protected abstract normalizeSource(
     source: boolean | string | SourceDefinition,
   );

--- a/src/Zns.ts
+++ b/src/Zns.ts
@@ -65,9 +65,9 @@ export default class Zns extends NamingService {
   async resolve(domain: string): Promise<ResolutionResult | null> {
     if (!this.isSupportedDomain(domain) || !this.isSupportedNetwork())
       return null;
-    const recordAddress = await this.getRecordsAddresses(domain);
-    if (!recordAddress) return null;
-    const [ownerAddress, resolverAddress] = recordAddress;
+    const recordAddresses = await this.getRecordsAddresses(domain);
+    if (!recordAddresses) return null;
+    const [ownerAddress, resolverAddress] = recordAddresses;
     const resolution = await this.getResolverRecordsStructure(resolverAddress);
     const addresses = _.mapValues(resolution.crypto, 'address');
     return {
@@ -80,10 +80,22 @@ export default class Zns extends NamingService {
     };
   }
 
-  async resolution(domain:string) : Promise<Object> {
+  async resolution(domain:string) : Promise<any | null> {
     if (!this.isSupportedDomain(domain) || !this.isSupportedNetwork())
       return null;
-    
+    const recordAddresses = await this.getRecordsAddresses(domain);
+    if (!recordAddresses) return null; 
+    const [ownerAddress, resolverAddress] = recordAddresses;
+    const resolution = await this.getResolverRecordsStructure(resolverAddress);
+    return {
+      resolution: _.omit(resolution, ['crypto']),
+      addresses: _.mapValues(resolution.crypto, 'address'),
+      meta: {
+        owner: ownerAddress || null,
+        type: 'zns',
+        ttl: parseInt(resolution.ttl as string) || 0
+      }
+    };
   }
 
   isSupportedDomain(domain: string): boolean {

--- a/src/Zns.ts
+++ b/src/Zns.ts
@@ -65,10 +65,10 @@ export default class Zns extends NamingService {
   async resolve(domain: string): Promise<ResolutionResult | null> {
     if (!this.isSupportedDomain(domain) || !this.isSupportedNetwork())
       return null;
-    const recordAddresses = await this.getRecordsAddresses(domain);
+    const recordAddresses = await this._getRecordsAddresses(domain);
     if (!recordAddresses) return null;
     const [ownerAddress, resolverAddress] = recordAddresses;
-    const resolution = await this.getResolverRecordsStructure(resolverAddress);
+    const resolution = await this._getResolverRecordsStructure(resolverAddress);
     const addresses = _.mapValues(resolution.crypto, 'address');
     return {
       addresses,
@@ -85,13 +85,13 @@ export default class Zns extends NamingService {
    * @param domain - domain name to be resolved
    * @returns - Everything what is stored on specified domain
    */
-  async resolution(domain: string): Promise<any | null> {
+  async resolution(domain: string): Promise<Object | {}> {
     if (!this.isSupportedDomain(domain) || !this.isSupportedNetwork())
       return null;
-    const recordAddresses = await this.getRecordsAddresses(domain);
+    const recordAddresses = await this._getRecordsAddresses(domain);
     if (!recordAddresses) return null;
     const [_, resolverAddress] = recordAddresses;
-    return await this.getResolverRecordsStructure(resolverAddress);
+    return await this._getResolverRecordsStructure(resolverAddress);
   }
 
   isSupportedDomain(domain: string): boolean {
@@ -102,7 +102,11 @@ export default class Zns extends NamingService {
     return this.registryAddress != null;
   }
 
-  async getRecordsAddresses(domain: string): Promise<[string, string] | null> {
+  /**
+   * @ignore
+   * @param domain - domain name
+   */
+  async _getRecordsAddresses(domain: string): Promise<[string, string] | null> {
     const registryRecord = await this.getContractMapValue(
       this.registry,
       'records',
@@ -119,7 +123,7 @@ export default class Zns extends NamingService {
     return [ownerAddress, resolverAddress];
   }
 
-  async getResolverRecordsStructure(
+  async _getResolverRecordsStructure(
     resolverAddress: string,
   ): Promise<ResolutionResult> {
     if (resolverAddress == NullAddress) {

--- a/src/Zns.ts
+++ b/src/Zns.ts
@@ -80,22 +80,18 @@ export default class Zns extends NamingService {
     };
   }
 
-  async resolution(domain:string) : Promise<any | null> {
+  /**
+   * Resolves a domain
+   * @param domain - domain name to be resolved
+   * @returns - Everything what is stored on specified domain
+   */
+  async resolution(domain: string): Promise<any | null> {
     if (!this.isSupportedDomain(domain) || !this.isSupportedNetwork())
       return null;
     const recordAddresses = await this.getRecordsAddresses(domain);
-    if (!recordAddresses) return null; 
-    const [ownerAddress, resolverAddress] = recordAddresses;
-    const resolution = await this.getResolverRecordsStructure(resolverAddress);
-    return {
-      resolution: _.omit(resolution, ['crypto']),
-      addresses: _.mapValues(resolution.crypto, 'address'),
-      meta: {
-        owner: ownerAddress || null,
-        type: 'zns',
-        ttl: parseInt(resolution.ttl as string) || 0
-      }
-    };
+    if (!recordAddresses) return null;
+    const [_, resolverAddress] = recordAddresses;
+    return await this.getResolverRecordsStructure(resolverAddress);
   }
 
   isSupportedDomain(domain: string): boolean {
@@ -106,7 +102,7 @@ export default class Zns extends NamingService {
     return this.registryAddress != null;
   }
 
-  async getRecordsAddresses(domain: string) : Promise<[string, string] | null> {
+  async getRecordsAddresses(domain: string): Promise<[string, string] | null> {
     const registryRecord = await this.getContractMapValue(
       this.registry,
       'records',
@@ -181,9 +177,7 @@ export default class Zns extends NamingService {
     field: string,
     keys: string[] = [],
   ): Promise<any> {
-    let result =
-      (await contract.getSubState(field, keys)) ||
-      {};
+    let result = (await contract.getSubState(field, keys)) || {};
     return result[field];
   }
 

--- a/src/Zns.ts
+++ b/src/Zns.ts
@@ -87,9 +87,9 @@ export default class Zns extends NamingService {
    */
   async resolution(domain: string): Promise<Object | {}> {
     if (!this.isSupportedDomain(domain) || !this.isSupportedNetwork())
-      return null;
+      return {};
     const recordAddresses = await this._getRecordsAddresses(domain);
-    if (!recordAddresses) return null;
+    if (!recordAddresses) return {};
     const [_, resolverAddress] = recordAddresses;
     return await this._getResolverRecordsStructure(resolverAddress);
   }


### PR DESCRIPTION
* Fixed the failing test on ens side
* Added Namicorn().zns#resolution(domain: string): Promise<Object | null>
* Extracted privately getNamingMethod inside the Namicorn()
* Added Ens#resolution(domain:string):Promise<Objkect | null> that always return null since ens doesn't support full ipfs resolution
* Added Namicorn#resolution(domain:string):Promise<Object | null> that chooses between ens and zns and runs appropriate method.resolution
* Expanded NamingService to contain resolution(domain:string)
* Added test functionality to check if resolution was made properly
 * Had to remove the private key for some functions in order to mock them with jest (looking for suggestions)