### PR TITLE
Fix types parameter in package.json to index.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.3",
   "description": "Crypto currency wallet domain name resolution library by Unstoppable Domains Inc.",
   "main": "./lib/index.js",
-  "types": "./lib/namicorn.d.ts",
+  "types": "./lib/index.d.ts",
   "scripts": {
     "release": "yarn build && yarn test && yarn publish --patch && yarn docs && yarn docs:deploy && yarn release:tag",
     "release:minor": "yarn build && yarn test && yarn publish --minor && yarn docs && yarn docs:deploy && yarn release:tag",


### PR DESCRIPTION
I believe this is what was really intended. Pointing to `./lib/namicorn.d.ts` makes integration with IDEs a little bit weird.